### PR TITLE
Add allow-update block

### DIFF
--- a/templates/named.conf.local.master.j2
+++ b/templates/named.conf.local.master.j2
@@ -11,6 +11,13 @@ zone "{{ master_zone.name }}" {
 {% endfor %}
     };
 {% endif %}
+{% if master_zone.allow_update is defined %}
+    allow-update {
+{% for allow_update in master_zone.allow_update %}
+        {{ allow_update }};
+{% endfor %}
+    };
+{% endif %}
 };
 
 {% endfor %}


### PR DESCRIPTION
This patch adds declaring arbitrary allow-update statements (just like allow-transfer) to master zones
