### PR TITLE
Only use forwarders if any are defined

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 bind_config_master_zones: []
 bind_config_master_allow_transfer: []
-bind_config_master_forwarders: [ '0.0.0.0' ]
+bind_config_master_forwarders: []
 bind_config_slave_zones: []
 bind_service_state: started
 bind_service_enabled: yes

--- a/templates/named.conf.options.j2
+++ b/templates/named.conf.options.j2
@@ -30,16 +30,16 @@ options {
 
         //provide-ixfr no ;
 
+	{% if bind_config_master_forwarders %}
         // If your ISP provided one or more IP addresses for stable
         // nameservers, you probably want to use them as forwarders.
-        // Uncomment the following block, and insert the addresses replacing
-        // the all-0's placeholder.
 
         forwarders {
         {% for forwarders in bind_config_master_forwarders %}
             {{ forwarders }};
         {% endfor %}
         };
+	{% endif %}
 
         //dnssec-enable yes;
         //dnssec-validation yes;


### PR DESCRIPTION
The `named.conf.options` templates defaults to a `forwarders` value of `0.0.0.0`, with a comment asking the user to change it. The `0.0.0.0` setting seems to slow lookups down (could just be coincidence, but if I remove the `forwarders` block altogether things seem to speed up noticeably. 

These patches cause `bind_config_master_forwarders` to default to an empty list, and makes the `named.conf.options` template only include a forwarders block if that list is populated. 