### PR TITLE
Recursion setting

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 bind_config_master_zones: []
 bind_config_master_allow_transfer: []
 bind_config_master_forwarders: [ '0.0.0.0' ]
+bind_config_recursion: yes
 bind_config_slave_zones: []
 bind_service_state: started
 bind_service_enabled: yes

--- a/templates/named.conf.options.j2
+++ b/templates/named.conf.options.j2
@@ -49,6 +49,6 @@ options {
         listen-on-v6 { any; };
 
         allow-query { any; };              // This is the default
-        recursion no;                      // Do not provide recursive service
+        recursion {{ bind_config_recursion }};                      // Do not provide recursive service
         zone-statistics yes;
 };


### PR DESCRIPTION
I'm rusty with bind, so I might be missing something, but I'm setting up a caching-only nameserver (not hosting a domain, just answering queries for local clients), and client queries just hang unless recursion is turned on. 

These patches add a `bind_config_recursion` setting that allows recursion to be controlled via an ansible variable. *(note that I also set the default to yes, which you may want to set to the old default of no instead)*