### PR TITLE
Set recursion to a safe default of "no"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 bind_config_master_zones: []
 bind_config_master_allow_transfer: []
 bind_config_master_forwarders: []
-bind_config_recursion: yes
+bind_config_recursion: "no"
 bind_config_slave_zones: []
 bind_service_state: started
 bind_service_enabled: yes


### PR DESCRIPTION
The previous default configuration configured the server to allow recursion for
the public internet which - because of its security implications - is
[a bad idea](http://dns.measurement-factory.com/surveys/openresolvers.html).

So its better to deactivate recursion by default and let the admin decide based
on his use case (.e.g. acting as internal resolver/forwarder) if it should be
allowed.

Additionally it should be noted that "bind_config_recursion" takes literal
strings like "yes" / "no" as parameters. When the quotation marks are ommited
the YAML parser read a boolean value which is written as "True"/"False" when
applying the template. But named expects "yes" / "no" in its confugration
files.

Change-UUID: 9ecd9627a1b1490899cd54f608a46050