### PR TITLE
Add support for zones that are forwarded to another nameserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ Optionally: If your nameservers acts as a secondary nameserver, here is a sample
             - example.org
 
 
+Optionally: If you need to forward some zones directly to another nameserver, here is a sample:
+
+    bind_config_forward_zones:
+      - name: domains forwarded to 127.1.0.x nameservers
+        forwarders: [ '127.1.0.1', '127.1.0.2' ]
+        forward: only
+        zones:
+          - forwarded.example.net
+          - forwarded.example.org
+
+*forward* should be either _first_ or _only_
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ bind_config_master_allow_transfer: []
 bind_config_master_forwarders: []
 bind_config_recursion: yes
 bind_config_slave_zones: []
+bind_config_forward_zones: []
 bind_service_state: started
 bind_service_enabled: yes
 bind_pkg_state: installed

--- a/files/named.conf
+++ b/files/named.conf
@@ -40,3 +40,4 @@ zone "255.in-addr.arpa" {
 include "/etc/bind/named.conf.local";
 include "/etc/bind/named.conf.local.master";
 include "/etc/bind/named.conf.local.slave";
+include "/etc/bind/named.conf.local.forward";

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
   with_items:
   - master
   - slave
+  - forward
   notify: reload bind
   tags: configuration
 

--- a/templates/named.conf.local.forward.j2
+++ b/templates/named.conf.local.forward.j2
@@ -4,8 +4,8 @@
 {% for zone in fwd_zone.zones %}
 zone "{{ zone }}" {
     type forward;
-{% if zone.forward is defined %}
-    forward {{ zone.forward }}; 
+{% if fwd_zone.forward is defined %}
+    forward {{ fwd_zone.forward }}; 
 {% endif %}
     forwarders {
 {% for fwder in fwd_zone.forwarders %}

--- a/templates/named.conf.local.forward.j2
+++ b/templates/named.conf.local.forward.j2
@@ -6,6 +6,8 @@ zone "{{ zone }}" {
     type forward;
 {% if fwd_zone.forward is defined %}
     forward {{ fwd_zone.forward }}; 
+{% else %}
+    forward only;
 {% endif %}
     forwarders {
 {% for fwder in fwd_zone.forwarders %}

--- a/templates/named.conf.local.forward.j2
+++ b/templates/named.conf.local.forward.j2
@@ -1,0 +1,17 @@
+## {{ ansible_managed }}
+{% for fwd_zone in bind_config_forward_zones %}
+######## {{ fwd_zone.name }} ({{ fwd_zone.zones|count }} zones)
+{% for zone in fwd_zone.zones %}
+zone "{{ zone }}" {
+    type forward;
+{% if zone.forward is defined %}
+    forward {{ zone.forward }}; 
+{% endif %}
+    forwarders {
+{% for fwder in fwd_zone.forwarders %}
+          {{ fwder }};
+{% endfor %}
+    };
+};
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
This pull request adds support for "forward" zones in bind.  These are zones for which queries are immediately sent to another nameserver.  

a playbook that looks like this:

    bind_config_forward_zones:
          - name: domains forwarded to other nameserver
            forwarders: [ '10.10.10.10', '10.10.10.11' ]
            forward: only
            zones:
              - forwarded.com

results in bind config as follows:

    zone "forwarded.com" {
        type forward;
        forward only; 
        forwarders {
             10.10.10.10;
             10.10.10.11;
        };
    };
