### PR TITLE
check configuration files and some new options

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,14 +21,20 @@
   tags: configuration
 
 - name: configure bind
-  copy: src=named.conf dest={{ bind_config_basepath }}/named.conf owner={{ bind_user }} group={{ bind_group }} mode=0600 validate='named-checkconf %s'
-  notify: restart bind
+  copy: src=named.conf dest={{ bind_config_basepath }}/named.conf owner={{ bind_user }} group={{ bind_group }} mode=0600
   tags: configuration
 
 - name: configure bind options
-  template: src=named.conf.options.j2 dest={{ bind_config_basepath }}/named.conf.options owner={{ bind_user }} group={{ bind_group }} mode=0600 validate='named-checkconf %s'
-  notify: restart bind
+  template: src=named.conf.options.j2 dest={{ bind_config_basepath }}/named.conf.options owner={{ bind_user }} group={{ bind_group }} mode=0600
   tags: configuration
+
+- name: check files
+  command:  named-checkconf "{{ bind_config_basepath }}/{{ item}}"
+  with_items:
+    - named.conf
+    - named.conf.options
+  notify: restart bind
+
 
 - name: Copy master zone files
   copy: src={{ bind_masterzones_path }}/db.{{ item.name }} dest={{ bind_base_zones_path }}/{{bind_masterzones_path}} owner={{ bind_user }} group={{ bind_group }}

--- a/templates/named.conf.local.master.j2
+++ b/templates/named.conf.local.master.j2
@@ -4,6 +4,13 @@
 zone "{{ master_zone.name }}" {
     type master;
     file "{{bind_base_zones_path}}/{{bind_masterzones_path}}/db.{{ master_zone.name }}";
+{% if master_zone.allow_query is defined %}
+    allow-query {
+{% for allow_query in master_zone.allow_query %}
+        {{ allow_query }};
+{% endfor %}
+    };
+{% endif %}
 {% if master_zone.allow_transfer is defined %}
     allow-transfer {
 {% for allow_transfer in master_zone.allow_transfer %}
@@ -16,6 +23,22 @@ zone "{{ master_zone.name }}" {
 {% for allow_update in master_zone.allow_update %}
         {{ allow_update }};
 {% endfor %}
+    };
+{% endif %}
+
+{% if master_zone.slave is defined or bind_config_master_allow_transfer is defined %}
+    notify explicit;
+    also-notify {
+{% if bind_config_master_allow_transfer is defined %}    
+{% for notify_update in  bind_config_master_allow_transfer %}
+        {{ notify_update }};
+{% endfor %}
+{% endif %}
+{% if master_zone.slave is defined %}
+{% for notify_update in master_zone.slave %}
+        {{ notify_update }};
+{% endfor %}
+{% endif %}
     };
 {% endif %}
 };

--- a/templates/named.conf.options.j2
+++ b/templates/named.conf.options.j2
@@ -23,11 +23,6 @@ options {
         {% endfor %}
         };
 
-        notify yes;
-
-        also-notify {
-        };
-
         //provide-ixfr no ;
 
 	{% if bind_config_master_forwarders %}
@@ -49,6 +44,15 @@ options {
         listen-on-v6 { any; };
 
         allow-query { any; };              // This is the default
-        recursion {{ bind_config_recursion }};                      // Do not provide recursive service
+
+	{% if bind_config_recursion %}
+        // If you want to limit whose can use the recursion method.
+
+        allow-recursion {
+        {% for network in bind_config_recursion %}
+            {{ network }};
+        {% endfor %}
+        };
+	{% endif %}
         zone-statistics yes;
 };


### PR DESCRIPTION
I've tried to use this role with a clean debian instalation.

First of all, "configure bind" and "configure bind options" tasks fail, because the files in question don't exist.

Then, I believe it is better to use a zone-specific notify statement.

And finally, an option was added to configure the allow-query statement by specific zones.
