### PR TITLE
add listen option defaulting to any

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@ bind_pkg_state: installed
 bind_base_zones_path: '/var/lib/bind'
 bind_masterzones_path: 'masters'
 bind_slavezones_path: 'slaves'
+bind_config_listen_on: any

--- a/templates/named.conf.options.j2
+++ b/templates/named.conf.options.j2
@@ -45,7 +45,8 @@ options {
         //dnssec-validation yes;
 
         auth-nxdomain no;    # conform to RFC1035
-  
+        
+        listen-on { {{ bind_config_listen_on }}; }; 
         listen-on-v6 { any; };
 
         allow-query { any; };              // This is the default


### PR DESCRIPTION
This simply add a listen option when for example you do not want bind to listen on all interfaces/addresses.