### PR TITLE
added optional global adjustment of allow-query

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Optionally: If you need to forward some zones directly to another nameserver, he
 
 *forward* should be either _first_ or _only_
 
+
+Optionally: If you want to adjust the allow-query option globally, here is a sample:
+
+    bind_config_allow_query: [ '127.1.0.1', '127.1.0.2' ]
+
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,4 @@ bind_base_zones_path: "/var/lib/bind"
 bind_masterzones_path: "masters"
 bind_slavezones_path: "slaves"
 bind_config_listen_on: any
+bind_config_allow_query: []

--- a/templates/named.conf.options.j2
+++ b/templates/named.conf.options.j2
@@ -49,7 +49,16 @@ options {
         listen-on { {{ bind_config_listen_on }}; }; 
         listen-on-v6 { any; };
 
+  {% if bind_config_allow_query %}
+      allow-query {
+      {% for queries in bind_config_allow_query %}
+        {{ queries }};
+      {% endfor %}
+      };
+  {% else %}
         allow-query { any; };              // This is the default
+  {% endif %}
+
         recursion {{ bind_config_recursion }};                      // Do not provide recursive service
         zone-statistics yes;
 };


### PR DESCRIPTION
Hi,

here comes a proposal to adjust the allow-query option globally in named.conf.options.
The patch wont change the current role behaviour.

Dont hesitate to ask any questions you might have.
Improvemnts are welcome.

Regards
Jard