### PR TITLE
Fixed variables for main.yml task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: install bind packages
   apt: pkg={{ item }} state={{ bind_pkg_state }}
-  with_items: bind_pkgs
+  with_items: "{{ bind_pkgs }}"
 
 - name: setup zone directories
   file: dest={{ bind_base_zones_path }}/{{ item }} state=directory owner={{ bind_user }} group={{ bind_group }} mode=0755
@@ -27,7 +27,7 @@
 
 - name: Copy master zone files
   copy: src={{ bind_masterzones_path }}/db.{{ item.name }} dest={{ bind_base_zones_path }}/{{bind_masterzones_path}} owner={{ bind_user }} group={{ bind_group }}
-  with_items: bind_config_master_zones
+  with_items: "{{ bind_config_master_zones }}"
   notify: reload bind
   tags: bind-zones
 


### PR DESCRIPTION
The "install bind packages" and "Copy master zone files" task variables were not being loaded correctly, resulting in failed tasks. This was fixed by surrounding them with quotes and brackets.