### PR TITLE
Adding dependency mention in README for #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Optionally: If you want to adjust the allow-query option globally, here is a sam
 
 ## Dependencies
 
-None.
+Debian or Ubuntu.
 
 
 ## Example Playbook


### PR DESCRIPTION
I could also work on a fix to support CentOS, but for now this at least clears up confusion in the README as the OS is a big dependency.