### PR TITLE
Simple allow-recursion parameter configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ bind_config_master_zones: []
 bind_config_master_allow_transfer: []
 bind_config_master_forwarders: []
 bind_config_recursion: "no"
+bind_config_allow_recursion: [127.0.0.1]
 bind_config_slave_zones: []
 bind_config_forward_zones: []
 bind_service_state: started

--- a/templates/named.conf.options.j2
+++ b/templates/named.conf.options.j2
@@ -56,9 +56,18 @@ options {
       {% endfor %}
       };
   {% else %}
-        allow-query { any; };              // This is the default
+        allow-query { any; }; // This is the default
   {% endif %}
 
-        recursion {{ bind_config_recursion }};                      // Do not provide recursive service
+        recursion {{ bind_config_recursion }}; // Do not provide recursive service
+
+  {% if bind_config_recursion %}
+        allow-recursion {
+          {% for bind_config_allow_recursion_item in bind_config_allow_recursion %}
+            {{ bind_config_allow_recursion_item }};
+          {% endfor %}
+        };
+  {% endif %}
+
         zone-statistics yes;
 };


### PR DESCRIPTION
Added bind_config_allow_recursion ansibel variable that's used in named.conf.options template.