### PR TITLE
Configuration options for notify, dns sec validation, local path to zone files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Optionally: If you want to adjust the allow-query option globally, here is a sam
     bind_config_allow_query: [ '127.1.0.1', '127.1.0.2' ]
 
 
+Optionally: If you want to use DNS-SEC validation, here is is how to enable this:
+
+    bind_config_dnssec_enabled: true
+
 ## Dependencies
 
 None.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Optionally: If you want to notify a server, here is a sample configuration. Note
             - 127.0.1.2
             - 127.0.2.3
 
+Optionally: If you want to disable default notify a server, here is a sample:
+
+      bind_config_master_zones:
+        # valid values for notify: "yes", "no", explicit. Make sure "yes" and "no" are strings
+        - name: example.com
+          notify: explicit
+
 Optionally: If you need to forward some zones directly to another nameserver, here is a sample:
 
     bind_config_forward_zones:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Optionally: If your nameservers acts as a secondary nameserver, here is a sample
             - example.net
             - example.org
 
+Optionally: If you want to notify a server, here is a sample configuration. Note that by default all servers in NS records will be notified.
+
+      bind_config_master_zones:
+        # also_notify is a list of IPs
+        - name: example.com
+          also_notify: [127.0.1.2]
+        - name: example.org
+          also_notify:
+            - 127.0.1.2
+            - 127.0.2.3
 
 Optionally: If you need to forward some zones directly to another nameserver, here is a sample:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,4 @@ bind_masterzones_path: "masters"
 bind_slavezones_path: "slaves"
 bind_config_listen_on: any
 bind_config_allow_query: []
+bind_config_dnssec_enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ bind_service_enabled: yes
 bind_pkg_state: installed
 bind_base_zones_path: "/var/lib/bind"
 bind_masterzones_path: "masters"
+bind_masterzones_local_path: "{{ bind_masterzones_path }}"
 bind_slavezones_path: "slaves"
 bind_config_listen_on: any
 bind_config_allow_query: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
   notify: restart bind
 
 - name: Copy master zone files
-  copy: src={{ bind_masterzones_path }}/db.{{ item.name }} dest={{ bind_base_zones_path }}/{{bind_masterzones_path}} owner={{ bind_user }} group={{ bind_group }}
+  copy: src={{ bind_masterzones_local_path }}/db.{{ item.name }} dest={{ bind_base_zones_path }}/{{bind_masterzones_path}} owner={{ bind_user }} group={{ bind_group }}
   with_items: "{{ bind_config_master_zones }}"
   notify: reload bind
   tags: bind-zones

--- a/templates/named.conf.local.master.j2
+++ b/templates/named.conf.local.master.j2
@@ -4,6 +4,9 @@
 zone "{{ master_zone.name }}" {
     type master;
     file "{{bind_base_zones_path}}/{{bind_masterzones_path}}/db.{{ master_zone.name }}";
+{% if master_zone.notify is defined and master_zone.notify in ['yes', 'no','explicit']  %}
+    notify {{ master_zone.notify }};
+{% endif %}
 {% if master_zone.allow_transfer is defined %}
     allow-transfer {
 {% for allow_transfer in master_zone.allow_transfer %}

--- a/templates/named.conf.local.master.j2
+++ b/templates/named.conf.local.master.j2
@@ -10,6 +10,14 @@ zone "{{ master_zone.name }}" {
         {{ allow_transfer }};
 {% endfor %}
     };
+    also-notify {
+{% if master_zone.also_notify is defined %}
+{% for notified_host in master_zone.also_notify %}
+        {{ notified_host }};
+{% endfor %}
+{% endif %}
+    };
+
 {% endif %}
 {% if master_zone.allow_update is defined %}
     allow-update {

--- a/templates/named.conf.options.j2
+++ b/templates/named.conf.options.j2
@@ -41,8 +41,10 @@ options {
         };
 	{% endif %}
 
-        //dnssec-enable yes;
-        //dnssec-validation yes;
+    {% if bind_config_dnssec_enabled %}
+        dnssec-enable yes;
+        dnssec-validation auto;
+    {% endif %}
 
         auth-nxdomain no;    # conform to RFC1035
         

--- a/templates/named.conf.options.j2
+++ b/templates/named.conf.options.j2
@@ -10,7 +10,7 @@ options {
         // port by default.
 
         //query-source address * port 53;
-  
+
         query-source address * port *;
 
         transfer-source *;
@@ -41,25 +41,25 @@ options {
         };
 	{% endif %}
 
-    {% if bind_config_dnssec_enabled %}
+{% if bind_config_dnssec_enabled %}
         dnssec-enable yes;
         dnssec-validation auto;
-    {% endif %}
+{% endif %}
 
         auth-nxdomain no;    # conform to RFC1035
-        
-        listen-on { {{ bind_config_listen_on }}; }; 
+
+        listen-on { {{ bind_config_listen_on }}; };
         listen-on-v6 { any; };
 
-  {% if bind_config_allow_query %}
+{% if bind_config_allow_query %}
       allow-query {
       {% for queries in bind_config_allow_query %}
         {{ queries }};
       {% endfor %}
       };
-  {% else %}
+{% else %}
         allow-query { any; };              // This is the default
-  {% endif %}
+{% endif %}
 
         recursion {{ bind_config_recursion }};                      // Do not provide recursive service
         zone-statistics yes;


### PR DESCRIPTION
This pull request adds support for several configuration options:

- DNS-SEC validation
- also-notify option in master zones
- notify option in master zones
- a configurable path where the zone files can be found on the Ansible machine

FYI: Signing zones with DNS-SEC is work in progress. When finished, I'll create a pull request for that as well.
